### PR TITLE
Fix to not hit an error on Blueprint_Install

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -88,7 +88,7 @@ namespace HMTBLite
 					__result = null;
 				}
 
-				else if (t is Blueprint blueprint && blueprint.MaterialsNeeded().NullOrEmpty())
+				else if (t is Blueprint_Build blueprint && blueprint.MaterialsNeeded().NullOrEmpty())
 				{
 					__result = null;
 				}


### PR DESCRIPTION
when re-installing buildings - that of course doesn't use materials, so:

Only call MaterialsNeeded() on Blueprint_Build, not Blueprint_Install